### PR TITLE
Adds geodistance filter operator for GPS Distance on Postgres/Postgis

### DIFF
--- a/api/src/database/helpers/geometry/dialects/postgres.ts
+++ b/api/src/database/helpers/geometry/dialects/postgres.ts
@@ -22,4 +22,16 @@ export class GeometryHelperPostgres extends GeometryHelper {
 	asGeoJSON(table: string, column: string): Knex.Raw {
 		return this.knex.raw('st_asgeojson(??.??) as ??', [table, column, column]);
 	}
+
+	override geodistance(key: string, latitude: number, longitude: number, range: number): Knex.Raw {
+		return this.knex.raw(
+			`ST_DWithin(
+				??::geography,
+				geography(ST_SetSRID(ST_MakePoint(?, ?), 4326)),
+				?
+			)
+			`,
+			[key, longitude, latitude, range],
+		);
+	}
 }

--- a/api/src/database/helpers/geometry/types.ts
+++ b/api/src/database/helpers/geometry/types.ts
@@ -64,4 +64,8 @@ export abstract class GeometryHelper extends DatabaseHelper {
 	collect(table: string, column: string): Knex.Raw {
 		return this.knex.raw('st_astext(st_collect(??.??))', [table, column]);
 	}
+
+	geodistance(_key: string, _latitude: number, _longitude: number, _range: number): Knex.Raw | null {
+		return null;
+	}
 }

--- a/api/src/database/run-ast/lib/apply-query/filter/operator.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/operator.ts
@@ -227,4 +227,23 @@ export function applyOperator(
 	if (operator == '_nintersects_bbox') {
 		dbQuery[logical].whereRaw(helpers.st.nintersects_bbox(key, compareValue));
 	}
+
+	if (operator == '_geodistance') {
+		// Expects compareValue in the format { latitude: number, longitude: number, range: number }
+		// range is the distance in meters
+		if (
+			compareValue &&
+			typeof compareValue === 'object' &&
+			'latitude' in compareValue &&
+			'longitude' in compareValue &&
+			'range' in compareValue
+		) {
+			const { latitude, longitude, range } = compareValue;
+			const whereClause = helpers.st.geodistance(key, latitude, longitude, range);
+
+			if (whereClause != null) {
+				dbQuery[logical].whereRaw(whereClause);
+			}
+		}
+	}
 }

--- a/packages/types/src/filter.ts
+++ b/packages/types/src/filter.ts
@@ -19,7 +19,8 @@ export type FilterOperator =
 	| 'intersects'
 	| 'nintersects'
 	| 'intersects_bbox'
-	| 'nintersects_bbox';
+	| 'nintersects_bbox'
+	| 'geodistance';
 
 export type ClientFilterOperator =
 	| FilterOperator
@@ -73,6 +74,7 @@ export type FieldFilterOperator = {
 	_nintersects?: string;
 	_intersects_bbox?: string;
 	_nintersects_bbox?: string;
+	_geodistance?: { latitude: number; longitude: number; range: number };
 };
 
 export type FieldValidationOperator = {

--- a/packages/utils/shared/get-filter-operators-for-type.test.ts
+++ b/packages/utils/shared/get-filter-operators-for-type.test.ts
@@ -116,6 +116,7 @@ describe('', () => {
 			'nintersects',
 			'intersects_bbox',
 			'nintersects_bbox',
+			'geodistance',
 		]);
 	});
 

--- a/packages/utils/shared/get-filter-operators-for-type.ts
+++ b/packages/utils/shared/get-filter-operators-for-type.ts
@@ -65,7 +65,7 @@ export function getFilterOperatorsForType(
 			return ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between', 'nbetween', 'null', 'nnull', 'in', 'nin'];
 
 		case 'geometry':
-			return ['eq', 'neq', 'null', 'nnull', 'intersects', 'nintersects', 'intersects_bbox', 'nintersects_bbox'];
+			return ['eq', 'neq', 'null', 'nnull', 'intersects', 'nintersects', 'intersects_bbox', 'nintersects_bbox', 'geodistance'];
 
 		default:
 			return [

--- a/readme_dev.md
+++ b/readme_dev.md
@@ -1,0 +1,56 @@
+## Quick start for Devs 🐰
+
+Create /api/.env and paste:
+```
+HOST="0.0.0.0"
+PORT=8055
+
+DB_CLIENT="pg"
+DB_HOST="localhost"
+DB_PORT=5100
+DB_PASSWORD="secret"
+DB_DATABASE="postgres"
+DB_USER="postgres"
+POSTGRES_URL="postgresql://postgres:secret@localhost:5111/postgres"
+
+ADMIN_EMAIL="admin@example.com"
+ADMIN_PASSWORD="d1r3ctu5"
+```
+
+Run Docker Compose and enable posgis
+```
+docker compose -f 'docker-compose.yml' up -d --build 'postgres'
+psql postgres://postgres@localhost:5100/postgres 
+pw is secret
+CREATE EXTENSION postgis;
+```
+
+Run the commands:
+```
+corepack enable pnpm
+pnpm install
+pnpm build
+pnpm --filter api cli bootstrap
+```
+
+
+(optional) If you want to use VS Code:
+in vs code in debugger create .vscode/launch.json
+´´´
+{
+	"version": "0.2.0",
+	"configurations": [
+
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Debug Api",
+			"skipFiles": ["<node_internals>/**"],
+			"cwd": "${workspaceFolder}/api",
+			"runtimeExecutable": "pnpm",
+			"runtimeArgs": ["run", "dev"],
+			"experimentalNetworking": "off"
+		}
+	]
+}
+´´´


### PR DESCRIPTION
(Note: This is a draft PR. As I need this feature this was my first attempt to start contributing to directus. As you can see this PR misses tests and implementations for other Datebases than postgres)

Implements the `_geodistance` filter operator for querying data within a specified radius of a geographic point.

This includes:
- Adding a `geodistance` method to the geometry helper for Postgres.
- Implementing the `_geodistance` operator logic within the query filter application.
- Validating the structure and values of the `_geodistance` filter object, ensuring that latitude, longitude, and range are valid numbers within allowed ranges.

The `_geodistance` operator allows users to filter results based on their proximity to a given location, enhancing spatial querying capabilities.

<!--

Heya! Thanks for opening a Pull Request! If your PR is implementing a new feature or fix for Directus, please make sure your PR adheres to the following requirements:

- The PR closes an Issue (not Discussion) ❌
- Tests are added/updated and are passing locally if applicable❌
- Documentation was added/updated if applicable❌

Please make sure to "Link" the issue you're closing. Without a Linked issue, this PR won't be accepted. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.

-->

## Scope

What's changed:

- Lorem ipsum dolor sit amet ❌

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet ❌

## Review Notes / Questions

- I would like to lorem ipsum ❌

---

Fixes #\<num\>
